### PR TITLE
Added g:xolox#reload#short_names option to reduce |hit-enter|

### DIFF
--- a/autoload/xolox/reload.vim
+++ b/autoload/xolox/reload.vim
@@ -33,6 +33,10 @@ endif
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
+if !exists('g:xolox#reload#short_names')
+  let g:xolox#reload#short_names = 0
+endif
+
 if !exists('s:reload_script_active')
   function! xolox#reload#script(filename) " {{{1
     let s:reload_script_active = 1
@@ -41,7 +45,11 @@ if !exists('s:reload_script_active')
       let filename = s:unresolve_scriptname(a:filename)
       for [callback, pattern] in s:scripttypes
         if filename =~ pattern
-          let friendly_name = filename
+          if g:xolox#reload#short_names
+            let friendly_name = fnamemodify(filename, ':t')
+          else
+            let friendly_name = filename
+          endif
           if pattern =~ 'ftplugin'
             " Determine include guard for generic file type plug-ins.
             let matches = matchlist(filename, pattern)

--- a/doc/reload.txt
+++ b/doc/reload.txt
@@ -89,6 +89,18 @@ This disables automatic reloading which means you'll have to reload scripts
 using the command discussed below.
 
 -------------------------------------------------------------------------------
+The *g:xolox#reload#short_names* option
+
+reload.vim reports when it reloads a file.  For long file paths, that report
+may be wider than the screen and so trigger a |hit-enter| prompt.  To avoid
+that, add the following line to your |vimrc|:
+>
+    let g:xolox#reload#short_names = 1
+<
+That will cause the report to include only the name of the file and not
+its full path.
+
+-------------------------------------------------------------------------------
 The *:ReloadScript* command
 
 You can execute the |:ReloadScript| command to reload the Vim script you're
@@ -121,7 +133,7 @@ complain that the command or function already exists:
   :command MyCmd call MyFun()
   :function MyFun()
   :endfunction
-  
+
   " Good:
   :command! MyCmd call MyFun()
   :function! MyFun()
@@ -139,7 +151,7 @@ several times:
   " Bad example: If the following line were re-evaluated, the message would
   " appear multiple times the next time the automatic command fires:
   :autocmd TabEnter * echomsg "Entered tab page"
-  
+
   " Good example: The following three lines can be reloaded without the
   " message appearing multiple times:
   :augroup MyPlugin


### PR DESCRIPTION
On my gvim, some of my file paths are long enough that they push the "Reloading XX script" messages past 80 characters.  The result is a |hit-enter| message.  This PR is a small change to report only the name of the file, not its path, if g:xolox#reload#short_names is set.  This shortens the "Reloading" message to reduce the chance of a |hit-enter|.

Thanks for considering this PR!